### PR TITLE
Allow custom tags when logging jobs performed by ActiveJob

### DIFF
--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -3,6 +3,7 @@ require "active_support/log_subscriber/test_helper"
 require "active_support/core_ext/numeric/time"
 require "jobs/hello_job"
 require "jobs/logging_job"
+require "jobs/custom_tags_logging_job"
 require "jobs/overridden_logging_job"
 require "jobs/nested_job"
 require "jobs/rescue_job"
@@ -131,5 +132,10 @@ class LoggingTest < ActiveSupport::TestCase
   rescue RescueJob::OtherError
     assert_match(/Performing RescueJob \(Job ID: .*?\) from .*? with arguments:.*other/, @logger.messages)
     assert_match(/Error performing RescueJob \(Job ID: .*?\) from .*? in .*ms: RescueJob::OtherError \(Bad hair\):\n.*\brescue_job\.rb:\d+:in `perform'/, @logger.messages)
+  end
+
+  def test_custom_tags_logging
+    CustomTagsLoggingJob.perform_later "Dummy", log_tags: ["123-456"]
+    assert_match(/\[123-456\]/, @logger.messages)
   end
 end

--- a/activejob/test/jobs/custom_tags_logging_job.rb
+++ b/activejob/test/jobs/custom_tags_logging_job.rb
@@ -1,0 +1,9 @@
+class CustomTagsLoggingJob < ActiveJob::Base
+  def perform(dummy, log_tags = nil)
+    logger.info "Dummy, here is it: #{dummy}"
+  end
+
+  def job_id
+    "LOGGING-JOB-ID"
+  end
+end


### PR DESCRIPTION
### Summary

The underlying purpose is to enable logging of (for example) the request ID of the initial HTTP request that triggers a background job when that job is performed. If there is a better way to accomplish that, I'd be very interested!

This PR enables custom tags to be passed into the job to be added to logs by ActiveJob when the job is performed. Currently ActiveJob adds the job name and job ID to the logger - this would enable additional tags.
 
By passing an additional argument to `perform_later` - taking the form `{log_tags: ['custom_tag1', 'custom_tag2'...]}` - those custom tags will be added to the logs generated within an ActiveJob job. 

This means you could, for example, pass in the `request_id` of the request that fired the job, and have the logs generated as the job is carried out tagged with the request that fired the job. (You would just need to have access to the request at the point the job is enqueued, using, for example, https://github.com/steveklabnik/request_store.